### PR TITLE
Feat/login: adds login menu item to make auth with email possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "electron-debug": "^1.0.0",
     "electron-dl": "^1.0.0",
-    "electron-osx-appearance": "^0.1.1"
+    "electron-osx-appearance": "^0.1.1",
+    "electron-prompt": "^1.1.0-1"
   },
   "devDependencies": {
     "electron-packager": "^7.0.0",

--- a/src/browser.js
+++ b/src/browser.js
@@ -2,6 +2,7 @@
 const electron = require('electron');
 const fs = require('fs');
 const ipc = electron.ipcRenderer;
+const prompt = require('electron-prompt');
 const BrowserWindow = electron.remote.BrowserWindow;
 const Common = require('./common');
 
@@ -51,6 +52,25 @@ ipc.on('open-settings', () => {
 	if (!clickAvatarMenuItem(9)) {
 		window.location = 'https://medium.com/me/settings';
 	}
+});
+
+ipc.on('open-login', () => {
+	prompt({
+    title: 'Enter the Login URL Received in Email',
+    label: 'Auth URL:',
+    value: '',
+    inputAttrs: {
+			type: 'url',
+			required: true
+    },
+    type: 'input'
+	})
+	.then((r) => {
+		if (r && r.indexOf('https://medium.com/m/callback') >= 0) {
+			window.location = r;
+		}
+	})
+	.catch(console.error);
 });
 
 ipc.on('open-home', () => {

--- a/src/menu.js
+++ b/src/menu.js
@@ -415,6 +415,13 @@ const otherTpl = [
 				}
 			},
 			{
+				label: 'Login',
+				accelerator: 'Ctrl+8',
+				click() {
+					sendAction('open-login');
+				}
+			},
+			{
 				label: 'Quit',
 				accelerator: 'Ctrl+W',
 				click() {

--- a/src/menu.js
+++ b/src/menu.js
@@ -234,7 +234,14 @@ const darwinTpl = [
 				click() {
 					sendAction('open-settings');
 				}
-			}
+			},
+			{
+				label: 'Login',
+				accelerator: 'Cmd+8',
+				click() {
+					sendAction('open-login');
+				}
+			},
 		]
 	},
 	{


### PR DESCRIPTION
This PR closes #37, I added a login menu item. Clicking on which opens an input box where user can enter the link they received and it'll then login them.